### PR TITLE
feat: allow setting host

### DIFF
--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -1,4 +1,4 @@
-import { debug } from "../global";
+import { gatewayURL, setToken } from "../global";
 import { makeError } from "../errors";
 
 function checkIfWeShouldUnlockTheLoginButton() {
@@ -21,9 +21,7 @@ export function setupListeners() {
             "click",
             async (e) => {
                 const response = await fetch(
-                    debug
-                        ? "http://127.0.0.1:5174/api/auth/login"
-                        : "https://chatapi.nin0.dev/api/auth/login",
+					`${gatewayURL}/api/auth/login`,
                     {
                         method: "POST",
                         body: JSON.stringify({
@@ -41,7 +39,7 @@ export function setupListeners() {
                 );
                 const responseJson = await response.json();
                 if (response.status === 200) {
-                    localStorage.setItem("nin0chat-token", responseJson.token);
+                    setToken(responseJson.token)
                     window.location.href = "/";
                 } else {
                     makeError(responseJson.error || "An error occurred, please try again later.");

--- a/src/domListeners.ts
+++ b/src/domListeners.ts
@@ -1,5 +1,5 @@
 import { addMessage, ws } from ".";
-import { token } from "./global";
+import { token, setToken } from "./global";
 import { sendMessage } from "./messageCreation";
 import { Message, Role } from "./utils";
 
@@ -12,7 +12,7 @@ export function setupListeners() {
 
             (document.querySelectorAll("#buttons-row a button")[0] as HTMLButtonElement).onclick =
                 () => {
-                    localStorage.removeItem("nin0chat-token");
+					setToken(null);
                     window.location.href = "/";
                 };
             (document.querySelectorAll("#buttons-row a")[0] as HTMLLinkElement).href = "";

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,5 +1,23 @@
-export const debug = !window.location.href.includes("nin0.dev");
-export const token = localStorage.getItem("nin0chat-token");
+// MDN says this exists
+interface Location {
+	searchParams
+}
+
+const { searchParams } = new URL(window.location.href)
+export const debug = searchParams.has("debug") ? parseInt(searchParams.get("debug")!) != 0 : !window.location.href.includes("nin0.dev");
+export const gatewayURL = searchParams.get("gateway") ?? (window.location.href.includes("nin0.dev") ? "wss://chatws.nin0.dev" : "ws://localhost:8928")
+export const tokenVarName = "nin0chat-token@" + gatewayURL
+export let token: string | null = localStorage.getItem("nin0chat-token@" + gatewayURL) ?? localStorage.getItem("nin0chat-token");
+
+if (localStorage.hasItem("nin0chat-token")) {
+	localStorage.setItem(tokenVarName, localStorage["nin0chat-token"])
+	delete localStorage["nin0chat-token"]
+}
+
+export function setToken(newToken: string | null) {
+	token = newToken
+	newToken ? (localStorage[tokenVarName] = newToken) : delete localStorage[tokenVarName]
+}
 
 export function configButtonsRow() {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { setupListeners } from "./domListeners";
 import { makeError } from "./errors";
-import { token } from "./global";
+import { token, gatewayURL } from "./global";
 import { Message, Role, shouldLogWebSocket } from "./utils";
 import { Converter } from "showdown";
 
@@ -11,9 +11,7 @@ mdConverter.setOption("simpleLineBreaks", true);
 mdConverter.setOption("simplifiedAutoLink", true);
 
 export function initWebSocket() {
-    ws = new WebSocket(
-        window.location.href.includes("nin0.dev") ? "wss://chatws.nin0.dev" : "ws://localhost:8928"
-    );
+    ws = new WebSocket(gatewayURL);
 
     ws!.onopen = function () {
         shouldLogWebSocket && console.log("Connected to ws");


### PR DESCRIPTION
This allows overriding the backend URL by setting ?gateway= on the chat page. (I feel that this would be best as a per-tab setting, but maybe it'd be possible to expose a better UI.) Additionally, login tokens will be stored per-gateway.
